### PR TITLE
Add: Clinic, Doctor, LabOrderモデルのバリデーションテストを追加

### DIFF
--- a/app/models/doctor.rb
+++ b/app/models/doctor.rb
@@ -1,3 +1,5 @@
 class Doctor < ApplicationRecord
   belongs_to :clinic
+
+  validates :name, presence: true
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -5,6 +5,6 @@ class Patient < ApplicationRecord
 
   validates :name, presence: true
   validates :chart_number, uniqueness: { scope: :clinic_id }, allow_blank: true
-  #　uniquenessに { scope: :clinic_id } をつけることで、
+  # 　uniquenessに { scope: :clinic_id } をつけることで、
   # 「他の医院には同じカルテ番号の人がいても良いが、同じ医院内では重複を許さない」という実務に即した仕様になる。
 end

--- a/spec/models/clinic_spec.rb
+++ b/spec/models/clinic_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Clinic, type: :model do
+  describe 'バリデーションのテスト' do
+    # 1. 正常系
+    it '医院名がある場合は有効であること' do
+      clinic = Clinic.new(name: '鈴木歯科医院')
+      expect(clinic).to be_valid
+    end
+
+    # 2. 異常系
+    it '医院名がない場合は無効であること' do
+      clinic = Clinic.new(name: nil)
+      expect(clinic).not_to be_valid
+      expect(clinic.errors[:name]).to include('を入力してください')
+    end
+  end
+end

--- a/spec/models/doctor_spec.rb
+++ b/spec/models/doctor_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Doctor, type: :model do
+  describe 'バリデーションのテスト' do
+    # 1. 異常系
+    it '医師名がない場合は無効であること' do
+      doctor = Doctor.new(name: nil)
+      expect(doctor).not_to be_valid
+      expect(doctor.errors[:name]).to include('を入力してください')
+    end
+  end
+end

--- a/spec/models/lab_order_spec.rb
+++ b/spec/models/lab_order_spec.rb
@@ -2,22 +2,30 @@ require 'rails_helper'
 
 RSpec.describe LabOrder, type: :model do
   describe 'メソッドのテスト' do
-    # 1つ目のテスト
+    # 1. 正常系
     it 'ステータスがpendingの場合、status_textが「未着手」を返すこと' do
       lab_order = LabOrder.new(status: 'pending')
       expect(lab_order.status_text).to eq '未着手'
     end
 
-    # 2つ目のテスト
+    # 2. 正常系
     it 'ステータスがprocessingの場合、status_textが「製作中」を返すこと' do
       lab_order = LabOrder.new(status: 'processing')
       expect(lab_order.status_text).to eq '製作中'
     end
 
-    # 3つ目のテスト
+    # 3. 正常系
     it 'tooth_numbersがカンマ区切りの文字列の場合、selected_teeth_listが配列を返すこと' do
       lab_order = LabOrder.new(tooth_numbers: '11,12,13')
       expect(lab_order.selected_teeth_list).to eq [ '11', '12', '13' ]
+    end
+  end
+
+  # 4. 異常系
+  describe 'バリデーションのテスト' do
+    it '患者（patient）が紐付いていない場合は無効であること' do
+      lab_order = LabOrder.new(patient: nil, status: 'pending')
+      expect(lab_order).not_to be_valid
     end
   end
 end


### PR DESCRIPTION
clinic_spec.rb、doctor_spec.rbのファイルを作成し、以下のとおりテストコードを実装しました。

1.lab_order_spec.rb
・患者（patient）が紐付いていない場合は無効であること

2.clinic_spec.rb
・医院名がある場合は有効であること
・医院名がない場合は無効であること

3.doctor_spec.rb
・医師名がない場合は無効であること